### PR TITLE
Add runtime rule management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ FlowSteer is a minimal SD-WAN L4 proxy written in Go. It demonstrates basic TCP
 and UDP forwarding with simple load balancing. The proxy exposes a small
 management API to update backends and forwarding rules at runtime.
 
+See [docs/PROCESS.md](docs/PROCESS.md) for an overview of how the proxy processes connections.
+
 ## Features
 
 - Round-robin balancing across multiple TCP backends.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ management API to update backends and forwarding rules at runtime.
 - Round-robin balancing across multiple TCP backends.
 - UDP forwarding to a single backend.
 - Management API to update backend list and five-tuple forwarding rules.
+- Automatic health checking of backends.
+- Rules can optionally bypass the proxy and connect directly to the original
+  destination.
 
 ## Building
 
@@ -49,7 +52,8 @@ The proxy starts an HTTP API (default `:9090`) with the following endpoints:
 {
   "rules": [
     { "src": "192.168.1.0/24", "dstPort": 8080,
-      "proto": "tcp", "backend": "10.0.0.1:9000" }
+      "proto": "tcp", "backend": "10.0.0.1:9000" },
+    { "dst": "10.1.1.0/24", "direct": true }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ management API to update backends and forwarding rules at runtime.
 - Automatic health checking of backends.
 - Rules can optionally bypass the proxy and connect directly to the original
   destination.
+- Propagates original connection information between proxies using the PROXY
+  protocol.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# FlowSteer
+
+FlowSteer is a minimal SD-WAN L4 proxy written in Go. It demonstrates basic TCP
+and UDP forwarding with simple load balancing. The proxy exposes a small
+management API to update backends and forwarding rules at runtime.
+
+## Features
+
+- Round-robin balancing across multiple TCP backends.
+- UDP forwarding to a single backend.
+- Management API to update backend list and five-tuple forwarding rules.
+
+## Building
+
+```
+go build ./cmd/proxy
+```
+
+## Usage
+
+Run the proxy listening on port 8080 with two backend servers:
+
+```
+./proxy -listen :8080 -backends 10.0.0.1:9000,10.0.0.2:9000
+```
+
+For UDP forwarding:
+
+```
+# in a separate program
+go run ./cmd/proxy -listen :5353 -backends 127.0.0.1:5354
+```
+
+This will forward UDP packets received on port 5353 to the backend.
+
+## Management API
+
+The proxy starts an HTTP API (default `:9090`) with the following endpoints:
+
+- `PUT /backends` – replace the backend list. Body format:
+
+```json
+{ "backends": ["10.0.0.1:9000", "10.0.0.2:9000"] }
+```
+
+- `PUT /rules` – replace five-tuple forwarding rules. Example body:
+
+```json
+{
+  "rules": [
+    { "src": "192.168.1.0/24", "dstPort": 8080,
+      "proto": "tcp", "backend": "10.0.0.1:9000" }
+  ]
+}
+```
+
+Existing connections are not affected when updating the configuration.
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See [docs/PROCESS.md](docs/PROCESS.md) for an overview of how the proxy processe
   protocol.
 - Works with iptables TPROXY redirection to capture the original destination
   using `SO_ORIGINAL_DST`.
+- Configuration can be loaded from a JSON file and backends are optional.
 
 ## Building
 
@@ -42,6 +43,29 @@ go run ./cmd/proxy -listen :5353 -backends 127.0.0.1:5354
 
 This will forward UDP packets received on port 5353 to the backend.
 
+Backends may be omitted entirely. In that case only rules that do not specify a
+backend (or specify `direct`) will cause traffic to be forwarded to the
+connection's original destination.
+
+### Configuration File
+
+Startup parameters can also be supplied in a JSON file using the `-config` flag.
+Fields mirror the command line options:
+
+```json
+{
+  "listen": ":8080",
+  "backends": ["10.0.0.1:9000", "10.0.0.2:9000"],
+  "api": ":9090"
+}
+```
+
+Launch with:
+
+```bash
+./proxy -config config.json
+```
+
 ## Management API
 
 The proxy starts an HTTP API (default `:9090`) with the following endpoints:
@@ -63,6 +87,9 @@ The proxy starts an HTTP API (default `:9090`) with the following endpoints:
   ]
 }
 ```
+
+A rule may omit the `backend` field to force the connection to be forwarded
+directly to its original destination.
 
 Existing connections are not affected when updating the configuration.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ management API to update backends and forwarding rules at runtime.
   destination.
 - Propagates original connection information between proxies using the PROXY
   protocol.
+- Works with iptables TPROXY redirection to capture the original destination
+  using `SO_ORIGINAL_DST`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,47 @@ directly to its original destination.
 
 Existing connections are not affected when updating the configuration.
 
+
+## Redirecting traffic with iptables TPROXY
+
+FlowSteer can operate as a transparent proxy by using iptables to intercept TCP or UDP traffic. Start the proxy normally (for example `sudo ./proxy -listen :8080` for TCP). Then configure the system to redirect connections:
+
+```bash
+# enable forwarding and load kernel modules
+sudo sysctl -w net.ipv4.ip_forward=1
+sudo modprobe xt_TPROXY nf_tproxy_ipv4
+
+# mark packets so they are routed back to the local machine
+sudo ip rule add fwmark 1 lookup 100
+sudo ip route add local 0.0.0.0/0 dev lo table 100
+
+# redirect TCP traffic to the proxy
+sudo iptables -t mangle -N FLOWSTEER
+sudo iptables -t mangle -A PREROUTING -p tcp -j FLOWSTEER
+sudo iptables -t mangle -A FLOWSTEER -p tcp -j TPROXY --on-port 8080 --tproxy-mark 1
+
+# redirect UDP (example for DNS)
+sudo iptables -t mangle -A FLOWSTEER -p udp --dport 53 -j TPROXY --on-port 5353 --tproxy-mark 1
+```
+
+With these rules any matching packets are transparently forwarded through FlowSteer while their original destination is preserved.
+
+## NAT Traversal Deployment
+
+Running FlowSteer on both sides of a NAT allows traffic to cross network boundaries without direct port forwarding. A typical layout looks like:
+
+```
+client -> Public FlowSteer <=====> FlowSteer inside LAN -> internal service
+```
+
+1. **Public instance**: start FlowSteer on a host with a public IP.
+   ```bash
+   ./proxy -listen :9000 -api :9090
+   ```
+2. **Internal instance**: start another FlowSteer behind the NAT and configure it to use the public instance as its backend.
+   ```bash
+   ./proxy -listen :8000 -backends public.ip.address:9000 -api :9091
+   ```
+   Use iptables TPROXY on the internal gateway to send selected traffic to the internal instance.
+3. Traffic arriving at the public proxy is forwarded to the internal instance using the PROXY protocol which carries the original five‑tuple. The internal proxy connects to the final destination on the private network, achieving a simple form of NAT traversal.
+

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"log"
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/example/flowsteer/internal/proxy"
 )
@@ -28,7 +30,17 @@ func main() {
 		}
 	}()
 
-	l, err := net.Listen("tcp", *listen)
+	lc := net.ListenConfig{Control: func(network, address string, c syscall.RawConn) error {
+		var serr error
+		if err := c.Control(func(fd uintptr) {
+			serr = syscall.SetsockoptInt(int(fd), syscall.SOL_IP, syscall.IP_TRANSPARENT, 1)
+		}); err != nil {
+			return err
+		}
+		return serr
+	}}
+
+	l, err := lc.Listen(context.Background(), "tcp", *listen)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/example/flowsteer/internal/proxy"
+)
+
+func main() {
+	listen := flag.String("listen", ":8080", "listen address")
+	backends := flag.String("backends", "localhost:9000", "comma separated backend addresses")
+	apiAddr := flag.String("api", ":9090", "management API address")
+	flag.Parse()
+
+	beList := splitAndTrim(*backends)
+
+	p := proxy.New(beList)
+
+	go func() {
+		log.Printf("management API listening on %s", *apiAddr)
+		if err := serveAPI(p, *apiAddr); err != nil {
+			log.Fatalf("api server error: %v", err)
+		}
+	}()
+
+	l, err := net.Listen("tcp", *listen)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	log.Printf("listening on %s, backends=%v", *listen, beList)
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Printf("accept error: %v", err)
+			continue
+		}
+		go p.Handle(conn)
+	}
+}
+
+func splitAndTrim(s string) []string {
+	var out []string
+	for _, v := range strings.Split(s, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// serveAPI exposes endpoints to update backends and ACL rules.
+func serveAPI(p *proxy.SimpleProxy, addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/backends", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			var req struct {
+				Backends []string `json:"backends"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			p.UpdateBackends(req.Backends)
+		case http.MethodGet:
+			json.NewEncoder(w).Encode(struct {
+				Backends []string `json:"backends"`
+			}{p.Backends()})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc("/rules", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			var req struct {
+				Rules []ruleReq `json:"rules"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			var rules []proxy.ForwardRule
+			for _, rr := range req.Rules {
+				rule, err := parseRule(rr)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				rules = append(rules, rule)
+			}
+			p.UpdateRules(rules)
+		case http.MethodGet:
+			json.NewEncoder(w).Encode(struct {
+				Rules []proxy.ForwardRule `json:"rules"`
+			}{p.Rules()})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	return http.ListenAndServe(addr, mux)
+}
+
+type ruleReq struct {
+	Src     string `json:"src"`
+	Dst     string `json:"dst"`
+	SrcPort int    `json:"srcPort"`
+	DstPort int    `json:"dstPort"`
+	Proto   string `json:"proto"`
+	Backend string `json:"backend"`
+}
+
+func parseRule(r ruleReq) (proxy.ForwardRule, error) {
+	var fr proxy.ForwardRule
+	if r.Src != "" {
+		if _, n, err := net.ParseCIDR(r.Src); err == nil {
+			fr.SrcNet = n
+		} else {
+			return fr, err
+		}
+	}
+	if r.Dst != "" {
+		if _, n, err := net.ParseCIDR(r.Dst); err == nil {
+			fr.DstNet = n
+		} else {
+			return fr, err
+		}
+	}
+	fr.SrcPort = r.SrcPort
+	fr.DstPort = r.DstPort
+	fr.Proto = r.Proto
+	fr.Backend = r.Backend
+	return fr, nil
+}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -7,25 +7,44 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"syscall"
 
 	"github.com/example/flowsteer/internal/proxy"
 )
 
+type config struct {
+	Listen   string   `json:"listen"`
+	Backends []string `json:"backends"`
+	API      string   `json:"api"`
+}
+
 func main() {
+	cfgFile := flag.String("config", "", "configuration file in JSON format")
 	listen := flag.String("listen", ":8080", "listen address")
-	backends := flag.String("backends", "localhost:9000", "comma separated backend addresses")
+	backends := flag.String("backends", "", "comma separated backend addresses")
 	apiAddr := flag.String("api", ":9090", "management API address")
 	flag.Parse()
 
-	beList := splitAndTrim(*backends)
+	cfg := config{Listen: *listen, Backends: splitAndTrim(*backends), API: *apiAddr}
+	if *cfgFile != "" {
+		data, err := os.ReadFile(*cfgFile)
+		if err != nil {
+			log.Fatalf("failed to read config file: %v", err)
+		}
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			log.Fatalf("invalid config file: %v", err)
+		}
+	}
+
+	beList := cfg.Backends
 
 	p := proxy.New(beList)
 
 	go func() {
-		log.Printf("management API listening on %s", *apiAddr)
-		if err := serveAPI(p, *apiAddr); err != nil {
+		log.Printf("management API listening on %s", cfg.API)
+		if err := serveAPI(p, cfg.API); err != nil {
 			log.Fatalf("api server error: %v", err)
 		}
 	}()
@@ -40,11 +59,11 @@ func main() {
 		return serr
 	}}
 
-	l, err := lc.Listen(context.Background(), "tcp", *listen)
+	l, err := lc.Listen(context.Background(), "tcp", cfg.Listen)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	log.Printf("listening on %s, backends=%v", *listen, beList)
+	log.Printf("listening on %s, backends=%v", cfg.Listen, beList)
 
 	for {
 		conn, err := l.Accept()

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -117,6 +117,7 @@ type ruleReq struct {
 	DstPort int    `json:"dstPort"`
 	Proto   string `json:"proto"`
 	Backend string `json:"backend"`
+	Direct  bool   `json:"direct"`
 }
 
 func parseRule(r ruleReq) (proxy.ForwardRule, error) {
@@ -139,5 +140,6 @@ func parseRule(r ruleReq) (proxy.ForwardRule, error) {
 	fr.DstPort = r.DstPort
 	fr.Proto = r.Proto
 	fr.Backend = r.Backend
+	fr.Direct = r.Direct
 	return fr, nil
 }

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -1,0 +1,55 @@
+# FlowSteer Code Processing Flow
+
+This document describes how the proxy handles connections and how the main components interact.
+
+## Startup
+
+- `cmd/proxy/main.go` parses command-line flags to obtain the listening address, the initial list of backends and the API address.
+- A TCP listener is created with `IP_TRANSPARENT` enabled so the proxy can accept traffic redirected via iptables TPROXY.
+- The management API is started in a goroutine and exposes `/backends` and `/rules` for runtime configuration.
+
+## Accepting Connections
+
+- The main loop accepts incoming TCP connections and hands each connection to `SimpleProxy.Handle`.
+
+## Parsing Connection Information
+
+- `Handle` calls `parseConn` which reads an optional PROXY protocol header.
+- If a header is present, the original source and destination addresses are taken from it.
+- Otherwise the connection's local and remote addresses are used and `SO_ORIGINAL_DST` is queried on Linux to recover the original destination of TPROXY traffic.
+- The resulting `connInfo` contains the full five‑tuple used for rule selection and forwarding.
+
+## Rule Evaluation
+
+- `selectByRules` scans the configured forwarding rules (`ForwardRule` in `rule.go`).
+- A rule can specify source/destination networks, ports and protocol; it may also indicate `Direct` forwarding which bypasses load balancing and connects to the original destination.
+
+## Forwarding
+
+1. **Direct Mode**
+   - If a rule with `Direct` is matched, `directForward` is called.
+   - The connection is opened to the original destination and a PROXY header is sent so downstream proxies know the true five‑tuple.
+   - Data is proxied bidirectionally using `io.Copy`.
+
+2. **Backend Mode**
+   - Otherwise `nextBackend` selects a healthy backend in round‑robin fashion.
+   - A TCP connection is opened to that backend and a PROXY header describing the client tuple is sent.
+   - Two goroutines copy data between client and backend.
+
+## Health Checking
+
+- `healthLoop` periodically dials each backend (every five seconds by default).
+- Backends that fail the probe are marked unhealthy and skipped by `nextBackend` until they recover.
+
+## Management API
+
+- `serveAPI` (in `main.go`) listens on the configured API address.
+- `PUT /backends` replaces the backend list.
+- `PUT /rules` replaces the forwarding rules.
+- Existing connections continue using their previously selected backend; updates only affect new connections.
+
+## UDP Forwarding
+
+- `UDPProxy` in `udp.go` listens on a UDP socket and forwards packets to a single backend.
+- Responses from the backend are echoed back to the original sender.
+

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -28,7 +28,9 @@ This document describes how the proxy handles connections and how the main compo
 
 1. **Direct Mode**
    - If a rule with `Direct` is matched, `directForward` is called.
-   - The connection is opened to the original destination and a PROXY header is sent so downstream proxies know the true five‑tuple.
+   - The connection is opened to the original destination. If the inbound
+     connection used the PROXY protocol, that header is forwarded; otherwise no
+     PROXY header is sent.
    - Data is proxied bidirectionally using `io.Copy`.
 
 2. **Backend Mode**

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -28,9 +28,8 @@ This document describes how the proxy handles connections and how the main compo
 
 1. **Direct Mode**
    - If a rule with `Direct` is matched, `directForward` is called.
-   - The connection is opened to the original destination. If the inbound
-     connection used the PROXY protocol, that header is forwarded; otherwise no
-     PROXY header is sent.
+   - The connection is opened to the original destination without sending a
+     PROXY header.
    - Data is proxied bidirectionally using `io.Copy`.
 
 2. **Backend Mode**

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -4,7 +4,7 @@ This document describes how the proxy handles connections and how the main compo
 
 ## Startup
 
-- `cmd/proxy/main.go` parses command-line flags to obtain the listening address, the initial list of backends and the API address.
+- `cmd/proxy/main.go` parses command-line flags or an optional JSON config file to obtain the listening address, the initial list of backends and the API address.
 - A TCP listener is created with `IP_TRANSPARENT` enabled so the proxy can accept traffic redirected via iptables TPROXY.
 - The management API is started in a goroutine and exposes `/backends` and `/rules` for runtime configuration.
 
@@ -22,7 +22,7 @@ This document describes how the proxy handles connections and how the main compo
 ## Rule Evaluation
 
 - `selectByRules` scans the configured forwarding rules (`ForwardRule` in `rule.go`).
-- A rule can specify source/destination networks, ports and protocol; it may also indicate `Direct` forwarding which bypasses load balancing and connects to the original destination.
+- A rule can specify source/destination networks, ports and protocol. If a matching rule sets `Direct` or omits the `Backend` field the connection is forwarded directly to its original destination; otherwise the selected backend is used.
 
 ## Forwarding
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/flowsteer
+
+go 1.24.3

--- a/internal/proxy/origdst_linux.go
+++ b/internal/proxy/origdst_linux.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"encoding/binary"
+	"net"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+const soOriginalDst = 80
+
+// originalDst returns the original destination address for a NAT redirected
+// connection using SO_ORIGINAL_DST.
+func originalDst(conn *net.TCPConn) (string, error) {
+	rc, err := conn.SyscallConn()
+	if err != nil {
+		return "", err
+	}
+	var addr syscall.RawSockaddrInet4
+	var l = uint32(syscall.SizeofSockaddrInet4)
+	var serr error
+	if err := rc.Control(func(fd uintptr) {
+		_, _, e1 := syscall.Syscall6(syscall.SYS_GETSOCKOPT, fd,
+			uintptr(syscall.SOL_IP), uintptr(soOriginalDst),
+			uintptr(unsafe.Pointer(&addr)), uintptr(unsafe.Pointer(&l)), 0)
+		if e1 != 0 {
+			serr = e1
+		}
+	}); err != nil {
+		return "", err
+	}
+	if serr != nil {
+		return "", serr
+	}
+	ip := net.IPv4(addr.Addr[0], addr.Addr[1], addr.Addr[2], addr.Addr[3])
+	b := *(*[2]byte)(unsafe.Pointer(&addr.Port))
+	port := int(binary.BigEndian.Uint16(b[:]))
+	return net.JoinHostPort(ip.String(), strconv.Itoa(port)), nil
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,36 +5,58 @@ import (
 	"log"
 	"net"
 	"sync/atomic"
+	"time"
 )
 
 // SimpleProxy forwards TCP connections to a list of backend servers with round-robin balancing.
 // SimpleProxy forwards TCP connections to backend servers. The backend list and
 // forwarding rules can be updated at runtime.
+type backend struct {
+	addr  string
+	alive atomic.Bool
+}
+
+// SimpleProxy forwards TCP connections to backend servers. The backend list and
+// forwarding rules can be updated at runtime. Backend health is probed
+// periodically and only healthy backends are selected when possible.
 type SimpleProxy struct {
-	backends atomic.Value // []string
+	backends atomic.Value // []*backend
 	rules    atomic.Value // []ForwardRule
 	current  uint32
+	interval time.Duration
 }
 
 // New creates a new proxy with the given backend addresses.
 // New creates a new proxy with the given backend addresses.
 func New(backends []string) *SimpleProxy {
-	p := &SimpleProxy{}
-	p.backends.Store(backends)
+	p := &SimpleProxy{interval: 5 * time.Second}
+	p.UpdateBackends(backends)
 	p.rules.Store([]ForwardRule{})
+	go p.healthLoop()
 	return p
 }
 
 // UpdateBackends replaces the backend list used for new connections.
 func (p *SimpleProxy) UpdateBackends(b []string) {
-	p.backends.Store(append([]string(nil), b...))
+	var out []*backend
+	for _, addr := range b {
+		if addr == "" {
+			continue
+		}
+		be := &backend{addr: addr}
+		be.alive.Store(true)
+		out = append(out, be)
+	}
+	p.backends.Store(out)
 }
 
 // Backends returns the current backend list.
 func (p *SimpleProxy) Backends() []string {
-	b, _ := p.backends.Load().([]string)
-	out := make([]string, len(b))
-	copy(out, b)
+	bs, _ := p.backends.Load().([]*backend)
+	out := make([]string, 0, len(bs))
+	for _, b := range bs {
+		out = append(out, b.addr)
+	}
 	return out
 }
 
@@ -52,43 +74,54 @@ func (p *SimpleProxy) Rules() []ForwardRule {
 }
 
 // nextBackend returns the next backend address using round robin.
-func (p *SimpleProxy) nextBackend() string {
-	b, _ := p.backends.Load().([]string)
-	if len(b) == 0 {
-		return ""
+func (p *SimpleProxy) nextBackend() *backend {
+	bs, _ := p.backends.Load().([]*backend)
+	if len(bs) == 0 {
+		return nil
 	}
-	idx := atomic.AddUint32(&p.current, 1)
-	return b[int(idx)%len(b)]
+	start := atomic.AddUint32(&p.current, 1)
+	for i := 0; i < len(bs); i++ {
+		b := bs[int(start+uint32(i))%len(bs)]
+		if b.alive.Load() {
+			return b
+		}
+	}
+	return bs[int(start)%len(bs)]
 }
 
-func (p *SimpleProxy) selectByRules(c net.Conn) (string, bool) {
+func (p *SimpleProxy) selectByRules(c net.Conn) (string, bool, bool) {
 	rules, _ := p.rules.Load().([]ForwardRule)
 	if len(rules) == 0 {
-		return "", false
+		return "", false, false
 	}
 	laddr, lok := c.LocalAddr().(*net.TCPAddr)
 	raddr, rok := c.RemoteAddr().(*net.TCPAddr)
 	if !lok || !rok {
-		return "", false
+		return "", false, false
 	}
 	for _, r := range rules {
 		if r.Match(raddr.IP, raddr.Port, laddr.IP, laddr.Port, "tcp") {
-			return r.Backend, true
+			return r.Backend, r.Direct, true
 		}
 	}
-	return "", false
+	return "", false, false
 }
 
 // Handle starts a new goroutine to proxy the connection to a backend.
 func (p *SimpleProxy) Handle(client net.Conn) {
-	backendAddr, ok := p.selectByRules(client)
-	if !ok {
-		backendAddr = p.nextBackend()
-	}
-	if backendAddr == "" {
-		log.Printf("no backend available")
-		client.Close()
+	backendAddr, direct, ok := p.selectByRules(client)
+	if direct {
+		p.directForward(client)
 		return
+	}
+	if !ok {
+		be := p.nextBackend()
+		if be == nil {
+			log.Printf("no backend available")
+			client.Close()
+			return
+		}
+		backendAddr = be.addr
 	}
 
 	backend, err := net.Dial("tcp", backendAddr)
@@ -107,5 +140,48 @@ func proxyConn(src, dst net.Conn) {
 	defer dst.Close()
 	if _, err := io.Copy(dst, src); err != nil {
 		log.Printf("proxy error: %v", err)
+	}
+}
+
+// directForward forwards the connection to its original destination using
+// SO_ORIGINAL_DST. If the destination cannot be determined the connection is
+// closed.
+func (p *SimpleProxy) directForward(c net.Conn) {
+	tcp, ok := c.(*net.TCPConn)
+	if !ok {
+		c.Close()
+		return
+	}
+	dst, err := originalDst(tcp)
+	if err != nil {
+		log.Printf("failed to get original dst: %v", err)
+		c.Close()
+		return
+	}
+	backend, err := net.Dial("tcp", dst)
+	if err != nil {
+		log.Printf("failed to dial origin %s: %v", dst, err)
+		c.Close()
+		return
+	}
+	go proxyConn(c, backend)
+	go proxyConn(backend, c)
+}
+
+// healthLoop periodically checks backend reachability.
+func (p *SimpleProxy) healthLoop() {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		bs, _ := p.backends.Load().([]*backend)
+		for _, b := range bs {
+			conn, err := net.DialTimeout("tcp", b.addr, 2*time.Second)
+			if err != nil {
+				b.alive.Store(false)
+				continue
+			}
+			conn.Close()
+			b.alive.Store(true)
+		}
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -62,6 +62,20 @@ func parseConn(c net.Conn) (*connInfo, error) {
 		ci.dstIP = laddr.IP
 		ci.dstPort = laddr.Port
 	}
+	// attempt to get original destination when traffic arrives via TPROXY
+	if tcp, ok := c.(*net.TCPConn); ok {
+		if od, err := originalDst(tcp); err == nil {
+			host, portStr, _ := net.SplitHostPort(od)
+			if ci.dstIP == nil {
+				ci.dstIP = net.ParseIP(host)
+			}
+			if ci.dstPort == 0 {
+				p, _ := strconv.Atoi(portStr)
+				ci.dstPort = p
+			}
+			ci.origDst = od
+		}
+	}
 	return ci, nil
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"io"
+	"log"
+	"net"
+	"sync/atomic"
+)
+
+// SimpleProxy forwards TCP connections to a list of backend servers with round-robin balancing.
+// SimpleProxy forwards TCP connections to backend servers. The backend list and
+// forwarding rules can be updated at runtime.
+type SimpleProxy struct {
+	backends atomic.Value // []string
+	rules    atomic.Value // []ForwardRule
+	current  uint32
+}
+
+// New creates a new proxy with the given backend addresses.
+// New creates a new proxy with the given backend addresses.
+func New(backends []string) *SimpleProxy {
+	p := &SimpleProxy{}
+	p.backends.Store(backends)
+	p.rules.Store([]ForwardRule{})
+	return p
+}
+
+// UpdateBackends replaces the backend list used for new connections.
+func (p *SimpleProxy) UpdateBackends(b []string) {
+	p.backends.Store(append([]string(nil), b...))
+}
+
+// Backends returns the current backend list.
+func (p *SimpleProxy) Backends() []string {
+	b, _ := p.backends.Load().([]string)
+	out := make([]string, len(b))
+	copy(out, b)
+	return out
+}
+
+// UpdateRules replaces the forwarding rules.
+func (p *SimpleProxy) UpdateRules(r []ForwardRule) {
+	p.rules.Store(append([]ForwardRule(nil), r...))
+}
+
+// Rules returns the current rules.
+func (p *SimpleProxy) Rules() []ForwardRule {
+	r, _ := p.rules.Load().([]ForwardRule)
+	out := make([]ForwardRule, len(r))
+	copy(out, r)
+	return out
+}
+
+// nextBackend returns the next backend address using round robin.
+func (p *SimpleProxy) nextBackend() string {
+	b, _ := p.backends.Load().([]string)
+	if len(b) == 0 {
+		return ""
+	}
+	idx := atomic.AddUint32(&p.current, 1)
+	return b[int(idx)%len(b)]
+}
+
+func (p *SimpleProxy) selectByRules(c net.Conn) (string, bool) {
+	rules, _ := p.rules.Load().([]ForwardRule)
+	if len(rules) == 0 {
+		return "", false
+	}
+	laddr, lok := c.LocalAddr().(*net.TCPAddr)
+	raddr, rok := c.RemoteAddr().(*net.TCPAddr)
+	if !lok || !rok {
+		return "", false
+	}
+	for _, r := range rules {
+		if r.Match(raddr.IP, raddr.Port, laddr.IP, laddr.Port, "tcp") {
+			return r.Backend, true
+		}
+	}
+	return "", false
+}
+
+// Handle starts a new goroutine to proxy the connection to a backend.
+func (p *SimpleProxy) Handle(client net.Conn) {
+	backendAddr, ok := p.selectByRules(client)
+	if !ok {
+		backendAddr = p.nextBackend()
+	}
+	if backendAddr == "" {
+		log.Printf("no backend available")
+		client.Close()
+		return
+	}
+
+	backend, err := net.Dial("tcp", backendAddr)
+	if err != nil {
+		log.Printf("failed to connect to backend %s: %v", backendAddr, err)
+		client.Close()
+		return
+	}
+
+	go proxyConn(client, backend)
+	go proxyConn(backend, client)
+}
+
+func proxyConn(src, dst net.Conn) {
+	defer src.Close()
+	defer dst.Close()
+	if _, err := io.Copy(dst, src); err != nil {
+		log.Printf("proxy error: %v", err)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -159,7 +159,8 @@ func (p *SimpleProxy) selectByRules(srcIP net.IP, srcPort int, dstIP net.IP, dst
 	}
 	for _, r := range rules {
 		if r.Match(srcIP, srcPort, dstIP, dstPort, "tcp") {
-			return r.Backend, r.Direct, true
+			direct := r.Direct || r.Backend == ""
+			return r.Backend, direct, true
 		}
 	}
 	return "", false, false

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strconv"
 	"sync/atomic"
 	"time"
 )
@@ -14,6 +15,54 @@ import (
 type backend struct {
 	addr  string
 	alive atomic.Bool
+}
+
+// connInfo describes a connection with its original five-tuple.
+type connInfo struct {
+	net.Conn
+	srcIP     net.IP
+	srcPort   int
+	dstIP     net.IP
+	dstPort   int
+	origDst   string
+	fromProxy bool
+}
+
+// parseConn extracts connection information and handles the PROXY protocol.
+func parseConn(c net.Conn) (*connInfo, error) {
+	conn, src, dst, err := parseProxyHeader(c)
+	if err != nil {
+		return nil, err
+	}
+
+	ci := &connInfo{Conn: conn}
+	if src != "" && dst != "" {
+		ci.fromProxy = true
+		if host, portStr, err := net.SplitHostPort(src); err == nil {
+			ci.srcIP = net.ParseIP(host)
+			p, _ := strconv.Atoi(portStr)
+			ci.srcPort = p
+		}
+		if host, portStr, err := net.SplitHostPort(dst); err == nil {
+			ci.dstIP = net.ParseIP(host)
+			p, _ := strconv.Atoi(portStr)
+			ci.dstPort = p
+			ci.origDst = dst
+		}
+		return ci, nil
+	}
+
+	raddr, rok := c.RemoteAddr().(*net.TCPAddr)
+	laddr, lok := c.LocalAddr().(*net.TCPAddr)
+	if rok {
+		ci.srcIP = raddr.IP
+		ci.srcPort = raddr.Port
+	}
+	if lok {
+		ci.dstIP = laddr.IP
+		ci.dstPort = laddr.Port
+	}
+	return ci, nil
 }
 
 // SimpleProxy forwards TCP connections to backend servers. The backend list and
@@ -89,18 +138,13 @@ func (p *SimpleProxy) nextBackend() *backend {
 	return bs[int(start)%len(bs)]
 }
 
-func (p *SimpleProxy) selectByRules(c net.Conn) (string, bool, bool) {
+func (p *SimpleProxy) selectByRules(srcIP net.IP, srcPort int, dstIP net.IP, dstPort int) (string, bool, bool) {
 	rules, _ := p.rules.Load().([]ForwardRule)
 	if len(rules) == 0 {
 		return "", false, false
 	}
-	laddr, lok := c.LocalAddr().(*net.TCPAddr)
-	raddr, rok := c.RemoteAddr().(*net.TCPAddr)
-	if !lok || !rok {
-		return "", false, false
-	}
 	for _, r := range rules {
-		if r.Match(raddr.IP, raddr.Port, laddr.IP, laddr.Port, "tcp") {
+		if r.Match(srcIP, srcPort, dstIP, dstPort, "tcp") {
 			return r.Backend, r.Direct, true
 		}
 	}
@@ -109,16 +153,23 @@ func (p *SimpleProxy) selectByRules(c net.Conn) (string, bool, bool) {
 
 // Handle starts a new goroutine to proxy the connection to a backend.
 func (p *SimpleProxy) Handle(client net.Conn) {
-	backendAddr, direct, ok := p.selectByRules(client)
+	ci, err := parseConn(client)
+	if err != nil {
+		log.Printf("failed to parse connection: %v", err)
+		client.Close()
+		return
+	}
+
+	backendAddr, direct, ok := p.selectByRules(ci.srcIP, ci.srcPort, ci.dstIP, ci.dstPort)
 	if direct {
-		p.directForward(client)
+		p.directForward(ci)
 		return
 	}
 	if !ok {
 		be := p.nextBackend()
 		if be == nil {
 			log.Printf("no backend available")
-			client.Close()
+			ci.Close()
 			return
 		}
 		backendAddr = be.addr
@@ -127,12 +178,20 @@ func (p *SimpleProxy) Handle(client net.Conn) {
 	backend, err := net.Dial("tcp", backendAddr)
 	if err != nil {
 		log.Printf("failed to connect to backend %s: %v", backendAddr, err)
-		client.Close()
+		ci.Close()
 		return
 	}
 
-	go proxyConn(client, backend)
-	go proxyConn(backend, client)
+	// propagate original tuple to next proxy
+	if err := sendProxyHeader(backend, ci.srcIP, ci.srcPort, ci.dstIP, ci.dstPort); err != nil {
+		log.Printf("failed to send proxy header: %v", err)
+		ci.Close()
+		backend.Close()
+		return
+	}
+
+	go proxyConn(ci, backend)
+	go proxyConn(backend, ci)
 }
 
 func proxyConn(src, dst net.Conn) {
@@ -146,26 +205,38 @@ func proxyConn(src, dst net.Conn) {
 // directForward forwards the connection to its original destination using
 // SO_ORIGINAL_DST. If the destination cannot be determined the connection is
 // closed.
-func (p *SimpleProxy) directForward(c net.Conn) {
-	tcp, ok := c.(*net.TCPConn)
-	if !ok {
-		c.Close()
-		return
+func (p *SimpleProxy) directForward(ci *connInfo) {
+	dst := ci.origDst
+	if dst == "" {
+		tcp, ok := ci.Conn.(*net.TCPConn)
+		if !ok {
+			ci.Close()
+			return
+		}
+		var err error
+		dst, err = originalDst(tcp)
+		if err != nil {
+			log.Printf("failed to get original dst: %v", err)
+			ci.Close()
+			return
+		}
 	}
-	dst, err := originalDst(tcp)
-	if err != nil {
-		log.Printf("failed to get original dst: %v", err)
-		c.Close()
-		return
-	}
+
 	backend, err := net.Dial("tcp", dst)
 	if err != nil {
 		log.Printf("failed to dial origin %s: %v", dst, err)
-		c.Close()
+		ci.Close()
 		return
 	}
-	go proxyConn(c, backend)
-	go proxyConn(backend, c)
+	// propagate tuple when direct-forwarding through another proxy
+	if err := sendProxyHeader(backend, ci.srcIP, ci.srcPort, ci.dstIP, ci.dstPort); err != nil {
+		log.Printf("failed to send proxy header: %v", err)
+		ci.Close()
+		backend.Close()
+		return
+	}
+	go proxyConn(ci, backend)
+	go proxyConn(backend, ci)
 }
 
 // healthLoop periodically checks backend reachability.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -242,17 +242,8 @@ func (p *SimpleProxy) directForward(ci *connInfo) {
 		ci.Close()
 		return
 	}
-	// only propagate the original tuple if this connection arrived from a
-	// previous proxy. Direct connections to the origin should not receive
-	// a PROXY header.
-	if ci.fromProxy {
-		if err := sendProxyHeader(backend, ci.srcIP, ci.srcPort, ci.dstIP, ci.dstPort); err != nil {
-			log.Printf("failed to send proxy header: %v", err)
-			ci.Close()
-			backend.Close()
-			return
-		}
-	}
+	// Direct connections do not use the PROXY protocol when forwarding to
+	// the origin server.
 	go proxyConn(ci, backend)
 	go proxyConn(backend, ci)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -242,12 +242,16 @@ func (p *SimpleProxy) directForward(ci *connInfo) {
 		ci.Close()
 		return
 	}
-	// propagate tuple when direct-forwarding through another proxy
-	if err := sendProxyHeader(backend, ci.srcIP, ci.srcPort, ci.dstIP, ci.dstPort); err != nil {
-		log.Printf("failed to send proxy header: %v", err)
-		ci.Close()
-		backend.Close()
-		return
+	// only propagate the original tuple if this connection arrived from a
+	// previous proxy. Direct connections to the origin should not receive
+	// a PROXY header.
+	if ci.fromProxy {
+		if err := sendProxyHeader(backend, ci.srcIP, ci.srcPort, ci.dstIP, ci.dstPort); err != nil {
+			log.Printf("failed to send proxy header: %v", err)
+			ci.Close()
+			backend.Close()
+			return
+		}
 	}
 	go proxyConn(ci, backend)
 	go proxyConn(backend, ci)

--- a/internal/proxy/proxyproto.go
+++ b/internal/proxy/proxyproto.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// parseProxyHeader checks for a HAProxy PROXY protocol v1 header on conn.
+// If found, it returns the source and destination addresses from the header
+// and a wrapped net.Conn that will supply the remaining data.
+func parseProxyHeader(conn net.Conn) (net.Conn, string, string, error) {
+	r := bufio.NewReader(conn)
+	peek, err := r.Peek(6)
+	if err == nil && string(peek) == "PROXY " {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, "", "", err
+		}
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) != 6 {
+			return nil, "", "", fmt.Errorf("invalid PROXY header")
+		}
+		srcIP := fields[2]
+		dstIP := fields[3]
+		srcPort := fields[4]
+		dstPort := fields[5]
+		return &connReader{Conn: conn, r: r}, net.JoinHostPort(srcIP, srcPort), net.JoinHostPort(dstIP, dstPort), nil
+	}
+	return &connReader{Conn: conn, r: r}, "", "", nil
+}
+
+// sendProxyHeader writes a PROXY protocol v1 header to conn describing the given tuple.
+func sendProxyHeader(conn net.Conn, srcIP net.IP, srcPort int, dstIP net.IP, dstPort int) error {
+	proto := "TCP4"
+	if srcIP.To4() == nil || dstIP.To4() == nil {
+		proto = "TCP6"
+	}
+	header := fmt.Sprintf("PROXY %s %s %s %d %d\r\n", proto, srcIP.String(), dstIP.String(), srcPort, dstPort)
+	_, err := conn.Write([]byte(header))
+	return err
+}
+
+// connReader wraps a net.Conn with a bufio.Reader used to put bytes back after peeking.
+type connReader struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *connReader) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}

--- a/internal/proxy/rule.go
+++ b/internal/proxy/rule.go
@@ -1,0 +1,51 @@
+package proxy
+
+import (
+	"net"
+	"strings"
+)
+
+// ForwardRule associates a 5-tuple with a backend address.
+type ForwardRule struct {
+	SrcNet  *net.IPNet
+	DstNet  *net.IPNet
+	SrcPort int
+	DstPort int
+	Proto   string // tcp or udp
+	Backend string
+}
+
+// Match reports whether the rule matches the provided tuple.
+func (r ForwardRule) Match(srcIP net.IP, srcPort int, dstIP net.IP, dstPort int, proto string) bool {
+	if r.Proto != "" && !strings.EqualFold(r.Proto, proto) {
+		return false
+	}
+	if r.SrcNet != nil && (srcIP == nil || !r.SrcNet.Contains(srcIP)) {
+		return false
+	}
+	if r.DstNet != nil && (dstIP == nil || !r.DstNet.Contains(dstIP)) {
+		return false
+	}
+	if r.SrcPort != 0 && r.SrcPort != srcPort {
+		return false
+	}
+	if r.DstPort != 0 && r.DstPort != dstPort {
+		return false
+	}
+	return true
+}
+
+// ACL holds forwarding rules.
+type ACL struct {
+	Rules []ForwardRule
+}
+
+// SelectBackend returns the backend for the tuple if a rule matches.
+func (a *ACL) SelectBackend(srcIP net.IP, srcPort int, dstIP net.IP, dstPort int, proto string) (string, bool) {
+	for _, r := range a.Rules {
+		if r.Match(srcIP, srcPort, dstIP, dstPort, proto) {
+			return r.Backend, true
+		}
+	}
+	return "", false
+}

--- a/internal/proxy/rule.go
+++ b/internal/proxy/rule.go
@@ -7,12 +7,13 @@ import (
 
 // ForwardRule associates a 5-tuple with a backend address.
 type ForwardRule struct {
-	SrcNet  *net.IPNet
-	DstNet  *net.IPNet
-	SrcPort int
-	DstPort int
-	Proto   string // tcp or udp
-	Backend string
+	SrcNet  *net.IPNet `json:"src,omitempty"`
+	DstNet  *net.IPNet `json:"dst,omitempty"`
+	SrcPort int        `json:"srcPort,omitempty"`
+	DstPort int        `json:"dstPort,omitempty"`
+	Proto   string     `json:"proto,omitempty"` // tcp or udp
+	Backend string     `json:"backend,omitempty"`
+	Direct  bool       `json:"direct,omitempty"`
 }
 
 // Match reports whether the rule matches the provided tuple.

--- a/internal/proxy/udp.go
+++ b/internal/proxy/udp.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"log"
+	"net"
+)
+
+// UDPProxy forwards UDP packets to a backend.
+type UDPProxy struct {
+	backend string
+}
+
+// NewUDP creates a UDP proxy to a backend address.
+func NewUDP(backend string) *UDPProxy {
+	return &UDPProxy{backend: backend}
+}
+
+func (p *UDPProxy) Serve(localAddr string) error {
+	laddr, err := net.ResolveUDPAddr("udp", localAddr)
+	if err != nil {
+		return err
+	}
+	baddr, err := net.ResolveUDPAddr("udp", p.backend)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.ListenUDP("udp", laddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 65535)
+	for {
+		n, addr, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			log.Printf("udp read error: %v", err)
+			continue
+		}
+		_, err = conn.WriteToUDP(buf[:n], baddr)
+		if err != nil {
+			log.Printf("udp write error: %v", err)
+			continue
+		}
+		// echo response to sender
+		_, err = conn.WriteToUDP(buf[:n], addr)
+		if err != nil {
+			log.Printf("udp echo error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- replace static ACL with dynamic five-tuple rules
- expose HTTP API to update backend list and rules
- update README with API docs

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686789d87a40832ca58e4097babf494b