### PR TITLE
Add PROXY protocol option

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,17 @@
-FlowSteer
+# FlowSteer
+
+This is a simple TCP proxy example used for demonstration.
+
+## Usage
+
+```
+go run ./cmd/proxy -backend 127.0.0.1:9000 -listen :8080
+```
+
+### Flags
+
+- `-backend` — address of the backend to forward connections to.
+- `-listen` — address to listen for incoming connections.
+- `-proxy-protocol` — when set, a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) v1 header is sent to the backend with the client's original IP. This allows chained proxies (proxy1 → proxy2) to see the real client IP.
+
+Backends built with FlowSteer can parse this header using `proxy.ParseProxyHeader`.

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+
+	"flowsteer/internal/proxy"
+)
+
+func main() {
+	backend := flag.String("backend", "localhost:8080", "backend address")
+	enableProxyProtocol := flag.Bool("proxy-protocol", false, "enable PROXY protocol forwarding")
+	addr := flag.String("listen", ":8080", "listen address")
+	flag.Parse()
+
+	listener, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	p := &proxy.SimpleProxy{BackendAddr: *backend, EnableProxyProtocol: *enableProxyProtocol}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		go p.Handle(conn)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module flowsteer
+
+go 1.20

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+)
+
+// SimpleProxy forwards connections to a backend address.
+type SimpleProxy struct {
+	BackendAddr         string
+	EnableProxyProtocol bool
+}
+
+// Handle accepts a client connection and forwards it to the backend.
+func (p *SimpleProxy) Handle(client net.Conn) {
+	defer client.Close()
+
+	backend, err := net.Dial("tcp", p.BackendAddr)
+	if err != nil {
+		return
+	}
+	defer backend.Close()
+
+	if p.EnableProxyProtocol {
+		sendProxyHeader(client, backend)
+	}
+
+	go io.Copy(backend, client)
+	io.Copy(client, backend)
+}
+
+// sendProxyHeader writes a minimal PROXY protocol v1 header to backend.
+func sendProxyHeader(client net.Conn, backend net.Conn) {
+	caddr, _ := addrParts(client.RemoteAddr())
+	baddr, _ := addrParts(backend.LocalAddr())
+	header := fmt.Sprintf("PROXY TCP4 %s %s %d %d\r\n", caddr.IP, baddr.IP, caddr.Port, baddr.Port)
+	backend.Write([]byte(header))
+}
+
+// addr holds IP and port parts of an address.
+type addr struct {
+	IP   string
+	Port int
+}
+
+func addrParts(a net.Addr) (addr, error) {
+	tcpAddr, ok := a.(*net.TCPAddr)
+	if !ok {
+		return addr{}, fmt.Errorf("not TCP addr")
+	}
+	return addr{IP: tcpAddr.IP.String(), Port: tcpAddr.Port}, nil
+}
+
+// ParseProxyHeader parses a PROXY protocol v1 header from r and returns the source addr.
+func ParseProxyHeader(r *bufio.Reader) (net.Addr, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if len(line) < 6 || line[:5] != "PROXY" {
+		return nil, fmt.Errorf("missing PROXY header")
+	}
+	var proto, srcIP, dstIP string
+	var srcPort, dstPort int
+	if _, err := fmt.Sscanf(line, "PROXY %s %s %s %d %d", &proto, &srcIP, &dstIP, &srcPort, &dstPort); err != nil {
+		return nil, err
+	}
+	return &net.TCPAddr{IP: net.ParseIP(srcIP), Port: srcPort}, nil
+}


### PR DESCRIPTION
## Summary
- add a basic proxy implementation
- support optional PROXY protocol forwarding with `-proxy-protocol`
- document flags in README
- helper to parse PROXY protocol headers

## Testing
- `go build ./cmd/proxy`

------
https://chatgpt.com/codex/tasks/task_e_686b2a7b8658832caa17954dfc613112